### PR TITLE
Made errors be Grouped by describe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,65 @@
+# Based on https://github.com/PowerShell/xWebAdministration/blob/dev/appveyor.yml
+# MIT Licence:  https://github.com/PowerShell/xWebAdministration/blob/dev/LICENSE
+#---------------------------------#
+#      environment configuration  #
+#---------------------------------#
+# This is necessary to use WMF5
+os: WMF 5
+version: 1.0.{build}
+install:
+  - cinst -y pester
+  - ps: |
+      Get-PackageProvider -Name nuget -ForceBootstrap -Force 
+      Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+      @(find-module 'PScribo' -Repository PSGallery -ErrorAction SilentlyContinue) | Install-Module -force
+
+#---------------------------------#
+#      build configuration        #
+#---------------------------------#
+
+build: off
+
+#---------------------------------#
+#      test configuration         #
+#---------------------------------#
+
+test_script:
+    - ps: |
+        $testResultsFile = ".\TestsResults.xml"
+        $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
+        (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
+        if ($res.FailedCount -gt 0) {
+            throw "$($res.FailedCount) tests failed."
+        }
+
+
+#---------------------------------#
+#      deployment configuration   #
+#---------------------------------#
+
+# scripts to run before deployment
+deploy_script:
+  - ps: |
+      # Creating project artifact
+      $stagingDirectory = (Resolve-Path ..).Path
+      $manifest = Join-Path $pwd "Format-Pester\Format-Pester.psd1"
+      (Get-Content $manifest -Raw).Replace("1.0.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
+      $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
+      Add-Type -assemblyname System.IO.Compression.FileSystem
+      [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)
+
+      <# Creating NuGet package artifact
+       # Required New-NuSpec from https://github.com/PowerShell/DscResource.Tests/blob/404f6ceed63f692f72394e50ad6e736d4213bd89/TestHelper.psm1#L11
+      New-Nuspec -packageName $env:APPVEYOR_PROJECT_NAME -version $env:APPVEYOR_BUILD_VERSION -author "Erwan Quelin" -owners "equelin" -licenseUrl "https://github.com/equelin/Format-Pester/blob/master/LICENSE" -projectUrl "https://github.com/$($env:APPVEYOR_REPO_NAME)" -packageDescription $env:APPVEYOR_PROJECT_NAME -tags "Pester PScribo" -destinationPath .
+      nuget pack ".\$($env:APPVEYOR_PROJECT_NAME).nuspec" -outputdirectory .
+      $nuGetPackageName = $env:APPVEYOR_PROJECT_NAME + "." + $env:APPVEYOR_BUILD_VERSION + ".nupkg"
+      $nuGetPackagePath = (Get-ChildItem $nuGetPackageName).FullName#>
+
+      @(
+          # You can add other artifacts here
+          $zipFilePath
+          #$nuGetPackagePath
+      ) | % {
+          Write-Host "Pushing package $_ as Appveyor artifact"
+          Push-AppveyorArtifact $_
+        }

--- a/tests/unit/Format-Pester.tests.ps1
+++ b/tests/unit/Format-Pester.tests.ps1
@@ -1,0 +1,128 @@
+$script:mockedTestResultCount =0
+function New-MockedTestResult 
+{
+    param(
+        [ValidateSet('Passed','Failed')]
+        [String] $Result = 'Passed'
+    )
+
+    $script:mockedTestResultCount++;
+    $testResult = [PSCustomObject] @{
+                    Describe ="Mocked Describe ${script:mockedTestResultCount}"
+                    Context = $null
+                    Name = "Mocked test ${script:mockedTestResultCount}"
+                    Result = $Result
+                    Time = New-TimeSpan -Seconds 1
+                    FailureMessage = $null
+                    StackTrace = $null
+                    ErrorRecord = $null
+                    ParameterizedSuiteName = $null
+                    Parameters = $null
+                }
+
+    return $testResult                
+}
+function New-MockedTestResultCollection
+{
+    param(
+        [int] $passedCount = 0,
+        [int] $failedCount = 0,
+        [int] $skippedCount = 0,
+        [int] $pendingCount = 0,
+        [object[]] $testResult
+    )
+        $mockedTestResult = [PSCustomObject] @{
+            PassedCount = $passedCount
+            FailedCount = $failedCount
+            SkippedCount = $skippedCount
+            PendingCount = $pendingCount
+            TotalCount = $passedCount+$failedCount+$skippedCount+$pendingCount
+            TestResult = $testResult
+        }
+        return $mockedTestResult
+}
+
+Describe 'Format-Pester' {
+    BeforeAll {
+        # Backup the default parameters so we can restor them
+        # It must be a clone because it is an object, otherwise updates will update this 
+        # reference
+        $script:OriginalPSDefaultParameterValues = $Global:PSDefaultParameterValues.Clone()
+        
+        # If BeforeAll fails, Skip everything
+        $Global:PSDefaultParameterValues["It:Skip"]=$true
+        Get-Module Format-Pester -ErrorAction SilentlyContinue | Remove-Module
+        it 'Format-Pester should load without error' -Skip:$false {
+            {Import-Module "$PSScriptRoot\..\..\Format-Pester" -Force -Scope Global} | should not throw
+            Get-Module Format-Pester | should not be null
+
+            # Since BeforeAll has passed, set skip to false
+            $Global:PSDefaultParameterValues["It:Skip"]=$false
+        }
+    }
+
+    AfterAll{
+        $Global:PSDefaultParameterValues = $script:OriginalPSDefaultParameterValues
+    }
+
+    Context 'BaseFileName not specified' {
+        $mockedTestResult = New-MockedTestResultCollection -passedCount 1 -failedCount 1 `
+            -testResult @(
+                New-MockedTestResult -Result Passed
+                New-MockedTestResult -Result Failed
+            )
+
+        $logFolder = 'TestDrive:\logs'
+        if(!(Test-path $logFolder))
+        {
+            md $logFolder > $null
+        }
+        it 'Should not throw' {
+            {$mockedTestResult | Format-Pester -Path TestDrive:\logs -Format HTML} | Should not throw
+        }
+        
+        it 'should have used the default, Pester_Results' {
+            join-path TestDrive:\logs Pester_Results.Html | should exist
+        }
+    }
+
+    Context 'Result Processing - all passed' {
+        $mockedTestResult = New-MockedTestResultCollection -passedCount 2 -failedCount 0 `
+            -testResult @(
+                New-MockedTestResult -Result Passed
+                New-MockedTestResult -Result Passed
+            )
+
+        $logFolder = 'TestDrive:\logs'
+        if(!(Test-path $logFolder))
+        {
+            md $logFolder > $null
+        }
+        
+        # Pending test due to https://github.com/equelin/Format-Pester/issues/1
+        it 'should not throw when all results are passed' {
+            {$mockedTestResult | Format-Pester -Path TestDrive:\logs -Format HTML} | should not throw
+        }
+        
+    }
+
+    Context 'Result Processing - all failed' {
+        $mockedTestResult = New-MockedTestResultCollection -passedCount 0 -failedCount 2 `
+            -testResult @(
+                New-MockedTestResult -Result Failed
+                New-MockedTestResult -Result Failed
+            )
+
+        $logFolder = 'TestDrive:\logs'
+        if(!(Test-path $logFolder))
+        {
+            md $logFolder > $null
+        }
+        
+        # Pending test due to https://github.com/equelin/Format-Pester/issues/1
+        it 'should not throw when all results are failed' {
+            {$mockedTestResult | Format-Pester -Path TestDrive:\logs -Format HTML} | should not throw
+        }
+        
+    }
+}


### PR DESCRIPTION
I think this makes the document much more readable.  It also fixes issue #1 

For success, I don't group them and this inflated the TOC too much.

Test results are here:  https://ci.appveyor.com/project/TravisEz13/format-pester/build/1.0.15

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/equelin/format-pester/4)

<!-- Reviewable:end -->
